### PR TITLE
Fix Dwarven Furniture Three description

### DIFF
--- a/Defs/ResearchProjectDefs/LotRD_Research.xml
+++ b/Defs/ResearchProjectDefs/LotRD_Research.xml
@@ -3,12 +3,12 @@
 
   <ResearchTabDef>
     <defName>LotRD_DwarvesTab</defName>
-	<label>Dwarves, Khazâd</label>
+    <label>Dwarves, Khazâd</label>
   </ResearchTabDef>
 
   <ResearchProjectDef Name="DwarvenResearch" Abstract="True">
-	<techLevel>Neolithic</techLevel>
-	<tab>LotRD_DwarvesTab</tab>
+    <techLevel>Neolithic</techLevel>
+    <tab>LotRD_DwarvesTab</tab>
   </ResearchProjectDef>
 
   <ResearchProjectTagDef>
@@ -53,10 +53,10 @@
     <researchViewX>1.5</researchViewX>
     <researchViewY>0</researchViewY>
   </ResearchProjectDef>
-  
+
   <!--======== Column 2 =========-->
   <!--======= Dwarves Armor ======-->
-  
+
   <ResearchProjectDef ParentName="DwarvenResearch">
     <defName>LotRD_ArmorOne</defName>
     <label>Apparel of the Aulëonnar</label>
@@ -73,7 +73,7 @@
     <defName>LotRD_ArmorTwo</defName>
     <label>Shieldmaking and Chainmail</label>
     <description>Prepare your dwarves with armor and helmets for the horrors of war:\n- Longbeard chaincoat and helmet\n- Dwarf-shield</description>
-    <baseCost>250</baseCost>                                                 
+    <baseCost>250</baseCost>
     <prerequisites>
       <li>LotRD_ArmorOne</li>
     </prerequisites>
@@ -86,7 +86,6 @@
     <label>Armor of the Iron Hills</label>
     <description>Thicken your dwarves with iron apparel inspired by the dwarves from the iron hills:\n- Hill-dwarf armor and helmet\n- Hill-dwarf shield</description>
     <baseCost>500</baseCost>
-    
     <prerequisites>
       <li>LotRD_ArmorTwo</li>
     </prerequisites>
@@ -114,7 +113,6 @@
     <label>Dwarven Furniture</label>
     <description>The natural dwarven inclination to craft creates impressive furniture:\n- Dwarven stool\n- Dwarven table\n- Dwarven end table\n- Dwarven dresser\n- Dwarven game table</description>
     <baseCost>250</baseCost>
-    
     <tags>
       <li>LotRD_DwarfScenario</li>
     </tags>
@@ -126,18 +124,19 @@
     <defName>LotRD_FurnitureTwo</defName>
     <label>Dwarven Lighting</label>
     <description>Unlock dwarven furniture for providing light in dark places:\n- Dwarven chandelier\n- Dwarven candelabra\n- Dwarven brazier box\n- Dwarven dresser</description>
-    <baseCost>250</baseCost>
-    
+    <baseCost>200</baseCost>
     <researchViewX>0.75</researchViewX>
     <researchViewY>2</researchViewY>
+    <prerequisites>
+      <li>LotRD_FurnitureOne</li>
+    </prerequisites>
   </ResearchProjectDef>
 
   <ResearchProjectDef ParentName="DwarvenResearch">
     <defName>LotRD_FurnitureThree</defName>
     <label>Ithildin</label>
-    <description>Allows for the creation of special lighting using a mithril alloy:\n- Dwarven chandelier\n- Dwarven candelabra\n- Dwarven brazier box\n- Dwarven dresser</description>
+    <description>Allows for the creation of special lighting using a mithril alloy:\n- Dwarven ithildin wall light\n- Dwarven ithildin lamp</description>
     <baseCost>1000</baseCost>
-    
     <researchViewX>1.5</researchViewX>
     <researchViewY>2</researchViewY>
     <prerequisites>
@@ -153,7 +152,6 @@
     <label>Dwarven Fortress</label>
     <description>Create strong doors and sturdy walls worthy of your dwarves:\n- Dwarven reinforced door\n- Dwarven reinforced walls</description>
     <baseCost>500</baseCost>
-    
     <researchViewX>0</researchViewX>
     <researchViewY>3</researchViewY>
   </ResearchProjectDef>
@@ -166,7 +164,6 @@
     <prerequisites>
       <li>LotRD_StructuresOne</li>
     </prerequisites>
-    
     <researchViewX>0.75</researchViewX>
     <researchViewY>2.7</researchViewY>
   </ResearchProjectDef>
@@ -179,7 +176,6 @@
     <prerequisites>
       <li>LotRD_StructuresOne</li>
     </prerequisites>
-    
     <researchViewX>0.75</researchViewX>
     <researchViewY>3.3</researchViewY>
   </ResearchProjectDef>
@@ -191,7 +187,7 @@
     <defName>LotRD_Brewing</defName>
     <label>Dwarven Mead Brewing</label>
     <description>Unlock the powers of mead by turning raw mead wort into mead:\n\n- Fermenting barrel (mead)</description>
-    <baseCost>500</baseCost>    
+    <baseCost>500</baseCost>
     <researchViewX>1</researchViewX>
     <researchViewY>4</researchViewY>
   </ResearchProjectDef>
@@ -200,7 +196,7 @@
     <defName>LotRD_ToyMaking</defName>
     <label>Dwarven Toy Making</label>
     <description>Allows for the making of the following at a smithy:\n- Puzzle box\n- Marble labyrinth\n- Elf doll</description>
-    <baseCost>250</baseCost>    
+    <baseCost>250</baseCost>
     <researchViewX>1.75</researchViewX>
     <researchViewY>4</researchViewY>
   </ResearchProjectDef>

--- a/Defs/ThingDefs_Buildings/LotRD_FurnitureLighting.xml
+++ b/Defs/ThingDefs_Buildings/LotRD_FurnitureLighting.xml
@@ -1,20 +1,23 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Defs>
-  
+
   <ThingDef ParentName="ArtableFurnitureBase">
     <defName>LotRD_Chandelier</defName>
     <label>dwarven chandelier</label>
     <description>A metal or stone ceiling mount to light an area in the dwarven style. Can be automatically refueled with wax made from animal fats at a cooking station. Produces a very small amount of heat.</description>
-    <category>Building</category><thingCategories><li>Buildings</li></thingCategories>
-	<building>
-	  <isEdifice>false</isEdifice>
-	</building>
-	<clearBuildingArea>false</clearBuildingArea>
+    <category>Building</category>
+    <thingCategories>
+      <li>Buildings</li>
+    </thingCategories>
+    <building>
+      <isEdifice>false</isEdifice>
+    </building>
+    <clearBuildingArea>false</clearBuildingArea>
     <graphicData>
       <texPath>Things/Building/Furniture/edmundWulfgarthDwarvenChandelier</texPath>
       <graphicClass>Graphic_Single</graphicClass>
       <drawRotated>false</drawRotated>
-	  <drawSize>2.5</drawSize>  
+      <drawSize>2.5</drawSize>
       <damageData>
         <rect>(0.35,0.35,0.3,0.3)</rect>
       </damageData>
@@ -23,11 +26,11 @@
       <li>Metallic</li>
       <li>Stony</li>
     </stuffCategories>
-    <costStuffCount>110</costStuffCount>	
+    <costStuffCount>110</costStuffCount>
     <rotatable>false</rotatable>
     <altitudeLayer>MoteOverhead</altitudeLayer>
     <passability>Standable</passability>
-	<pathCost>8</pathCost>
+    <pathCost>8</pathCost>
     <tickerType>Normal</tickerType>
     <drawerType>RealtimeOnly</drawerType>
     <fillPercent>0.15</fillPercent>
@@ -35,8 +38,8 @@
       <MaxHitPoints>125</MaxHitPoints>
       <WorkToBuild>2600</WorkToBuild>
       <Flammability>0</Flammability>
-	  <Beauty>10</Beauty>
-      <Mass>4.5</Mass>	  
+      <Beauty>10</Beauty>
+      <Mass>4.5</Mass>
     </statBases>
     <selectable>true</selectable>
     <soundImpactDefault>BulletImpact_Ground</soundImpactDefault>
@@ -65,61 +68,66 @@
       </li>
       <li Class="CompOverlays.CompProperties_Overlays">
         <overlays>
-		  <li>
-			<graphicData>
-			  <texPath>Things/Special/Fire</texPath>
-			  <graphicClass>Dwarves.Graphic_CustomFlicker</graphicClass>
-			  <shaderType>TransparentPostLight</shaderType>
-			  <drawSize>0.5</drawSize>
-			</graphicData>
-			<offset>(0,-1.0,0)</offset>
-		  </li>
-		</overlays>
-	  </li>
+          <li>
+            <graphicData>
+              <texPath>Things/Special/Fire</texPath>
+              <graphicClass>Dwarves.Graphic_CustomFlicker</graphicClass>
+              <shaderType>TransparentPostLight</shaderType>
+              <drawSize>0.5</drawSize>
+            </graphicData>
+            <offset>(0,-1.0,0)</offset>
+          </li>
+        </overlays>
+      </li>
     </comps>
-	<placeWorkers>
+    <placeWorkers>
       <li>PlaceWorker_Heater</li>
       <li>JecsTools.PlaceWorker_UnderCeiling</li>
     </placeWorkers>
     <designationCategory>Furniture</designationCategory>
-    <researchPrerequisites><li>LotRD_FurnitureTwo</li></researchPrerequisites>
+    <researchPrerequisites>
+      <li>LotRD_FurnitureTwo</li>
+    </researchPrerequisites>
   </ThingDef>
-  
+
   <ThingDef ParentName="ArtableFurnitureBase">
     <defName>LotRD_DwarvenCandelabra</defName>
     <label>dwarven candelabra</label>
     <description>A mount for wax candles to light an area. Can be automatically refueled with wax. Produces a small amount of heat.</description>
-    <category>Building</category><thingCategories><li>Buildings</li></thingCategories>
-	<uiIconPath>Things/Building/Furniture/edmundWulfgarthDwarvenCandelabraUI</uiIconPath>	
+    <category>Building</category>
+    <thingCategories>
+      <li>Buildings</li>
+    </thingCategories>
+    <uiIconPath>Things/Building/Furniture/edmundWulfgarthDwarvenCandelabraUI</uiIconPath>
     <graphicData>
       <texPath>Things/Building/Furniture/edmundWulfgarthDwarvenCandelabra</texPath>
       <graphicClass>Graphic_Single</graphicClass>
       <drawRotated>false</drawRotated>
-	  <shaderType>CutoutComplex</shaderType>
-	  <drawSize>3.7</drawSize>
+      <shaderType>CutoutComplex</shaderType>
+      <drawSize>3.7</drawSize>
       <damageData>
         <rect>(0.35,0.35,0.3,0.3)</rect>
       </damageData>
     </graphicData>
     <stuffCategories>
-	  <li>Woody</li>
+      <li>Woody</li>
       <li>Metallic</li>
       <li>Stony</li>
     </stuffCategories>
-    <costStuffCount>70</costStuffCount>	
+    <costStuffCount>70</costStuffCount>
     <rotatable>false</rotatable>
     <altitudeLayer>BuildingOnTop</altitudeLayer>
     <passability>PassThroughOnly</passability>
-	<pathCost>8</pathCost>
+    <pathCost>8</pathCost>
     <tickerType>Normal</tickerType>
     <drawerType>RealtimeOnly</drawerType>
     <fillPercent>0.15</fillPercent>
     <statBases>
-      <Mass>4.2</Mass>	
+      <Mass>4.2</Mass>
       <MaxHitPoints>120</MaxHitPoints>
       <WorkToBuild>1600</WorkToBuild>
       <Flammability>0</Flammability>
-	  <Beauty>2</Beauty>
+      <Beauty>2</Beauty>
     </statBases>
     <selectable>true</selectable>
     <soundImpactDefault>BulletImpact_Ground</soundImpactDefault>
@@ -134,7 +142,7 @@
         <fuelConsumptionRate>0.5</fuelConsumptionRate>
         <fuelCapacity>20.0</fuelCapacity>
         <fuelConsumptionPerTickInRain>0.0006</fuelConsumptionPerTickInRain>
-		 <destroyOnNoFuel>false</destroyOnNoFuel>
+        <destroyOnNoFuel>false</destroyOnNoFuel>
         <fuelFilter>
           <thingDefs>
             <li>WoodLog</li>
@@ -151,69 +159,74 @@
       </li>
       <li Class="CompOverlays.CompProperties_Overlays">
         <overlays>
-		  <li>
-			<graphicData>
-			  <texPath>Things/Special/Fire</texPath>
-			  <graphicClass>Dwarves.Graphic_CustomFlicker</graphicClass>
-			  <shaderType>TransparentPostLight</shaderType>
-			  <drawSize>0.17</drawSize>
-			</graphicData>
-			<offset>(-0.21,0.1,1.015)</offset>
-		  </li>
-		  <li>
-			<graphicData>
-			  <texPath>Things/Special/Fire</texPath>
-			  <graphicClass>Dwarves.Graphic_CustomFlicker</graphicClass>
-			  <shaderType>TransparentPostLight</shaderType>
-			  <drawSize>0.17</drawSize>
-			</graphicData>
-			<offset>(-0.095,0.1,1.115)</offset>
-		  </li>
-		  <li>
-			<graphicData>
-			  <texPath>Things/Special/Fire</texPath>
-			  <graphicClass>Dwarves.Graphic_CustomFlicker</graphicClass>
-			  <shaderType>TransparentPostLight</shaderType>
-			  <drawSize>0.17</drawSize>
-			</graphicData>
-			<offset>(0,0.1,1.3)</offset>
-		  </li>
-		  <li>
-			<graphicData>
-			  <texPath>Things/Special/Fire</texPath>
-			  <graphicClass>Dwarves.Graphic_CustomFlicker</graphicClass>
-			  <shaderType>TransparentPostLight</shaderType>
-			  <drawSize>0.17</drawSize>
-			</graphicData>
-			<offset>(0.125,0.1,1.115)</offset>
-		  </li>
-		  <li>
-			<graphicData>
-			  <texPath>Things/Special/Fire</texPath>
-			  <graphicClass>Dwarves.Graphic_CustomFlicker</graphicClass>
-			  <shaderType>TransparentPostLight</shaderType>
-			  <drawSize>0.17</drawSize>
-			</graphicData>
-			<offset>(0.23,0.1,1.015)</offset>
-		  </li>
-		</overlays>
+          <li>
+            <graphicData>
+              <texPath>Things/Special/Fire</texPath>
+              <graphicClass>Dwarves.Graphic_CustomFlicker</graphicClass>
+              <shaderType>TransparentPostLight</shaderType>
+              <drawSize>0.17</drawSize>
+            </graphicData>
+            <offset>(-0.21,0.1,1.015)</offset>
+          </li>
+          <li>
+            <graphicData>
+              <texPath>Things/Special/Fire</texPath>
+              <graphicClass>Dwarves.Graphic_CustomFlicker</graphicClass>
+              <shaderType>TransparentPostLight</shaderType>
+              <drawSize>0.17</drawSize>
+            </graphicData>
+            <offset>(-0.095,0.1,1.115)</offset>
+          </li>
+          <li>
+            <graphicData>
+              <texPath>Things/Special/Fire</texPath>
+              <graphicClass>Dwarves.Graphic_CustomFlicker</graphicClass>
+              <shaderType>TransparentPostLight</shaderType>
+              <drawSize>0.17</drawSize>
+            </graphicData>
+            <offset>(0,0.1,1.3)</offset>
+          </li>
+          <li>
+            <graphicData>
+              <texPath>Things/Special/Fire</texPath>
+              <graphicClass>Dwarves.Graphic_CustomFlicker</graphicClass>
+              <shaderType>TransparentPostLight</shaderType>
+              <drawSize>0.17</drawSize>
+            </graphicData>
+            <offset>(0.125,0.1,1.115)</offset>
+          </li>
+          <li>
+            <graphicData>
+              <texPath>Things/Special/Fire</texPath>
+              <graphicClass>Dwarves.Graphic_CustomFlicker</graphicClass>
+              <shaderType>TransparentPostLight</shaderType>
+              <drawSize>0.17</drawSize>
+            </graphicData>
+            <offset>(0.23,0.1,1.015)</offset>
+          </li>
+        </overlays>
       </li>
     </comps>
     <designationCategory>Furniture</designationCategory>
-    <researchPrerequisites><li>LotRD_FurnitureTwo</li></researchPrerequisites>
+    <researchPrerequisites>
+      <li>LotRD_FurnitureTwo</li>
+    </researchPrerequisites>
   </ThingDef>
-  
+
   <ThingDef ParentName="FurnitureWithQualityBase">
     <defName>LotRD_Brazier</defName>
     <label>dwarven brazier box</label>
-	<thingClass>Building</thingClass>
+    <thingClass>Building</thingClass>
     <description>A pit for a flame to grow and light its surroundings.</description>
-    <category>Building</category><thingCategories><li>Buildings</li></thingCategories>
+    <category>Building</category>
+    <thingCategories>
+      <li>Buildings</li>
+    </thingCategories>
     <graphicData>
       <texPath>Things/Building/Furniture/edmundWulfgarthDwarvenBrazier</texPath>
       <graphicClass>Graphic_Single</graphicClass>
       <drawRotated>false</drawRotated>
-	  <drawSize>1</drawSize>
+      <drawSize>1</drawSize>
       <damageData>
         <rect>(0.35,0.35,0.3,0.3)</rect>
       </damageData>
@@ -226,13 +239,13 @@
     <drawerType>RealtimeOnly</drawerType>
     <fillPercent>0.8</fillPercent>
     <stuffCategories>
-	  <li>Woody</li>
+      <li>Woody</li>
       <li>Metallic</li>
       <li>Stony</li>
     </stuffCategories>
-    <costStuffCount>20</costStuffCount>	
+    <costStuffCount>20</costStuffCount>
     <statBases>
-	  <Mass>10</Mass>
+      <Mass>10</Mass>
       <MaxHitPoints>85</MaxHitPoints>
       <WorkToBuild>220</WorkToBuild>
       <Flammability>0</Flammability>
@@ -271,42 +284,47 @@
       </li>
       <li Class="CompOverlays.CompProperties_Overlays">
         <overlays>
-		  <li>
-		    <usesStuff>true</usesStuff>
-			<graphicData>
-			  <texPath>Things/Building/Furniture/edmundWulfgarthDwarvenBrazier_overlay</texPath>
-			  <graphicClass>Graphic_Single</graphicClass>
-			  <drawRotated>false</drawRotated>
-			  <drawSize>1</drawSize>
-			  <damageData>
-				<rect>(0.35,0.35,0.3,0.3)</rect>
-			  </damageData>
-			</graphicData>
-			<offset>(0,1.0,0)</offset>
-		  </li>
-		</overlays>
-	  </li>
+          <li>
+            <usesStuff>true</usesStuff>
+            <graphicData>
+              <texPath>Things/Building/Furniture/edmundWulfgarthDwarvenBrazier_overlay</texPath>
+              <graphicClass>Graphic_Single</graphicClass>
+              <drawRotated>false</drawRotated>
+              <drawSize>1</drawSize>
+              <damageData>
+                <rect>(0.35,0.35,0.3,0.3)</rect>
+              </damageData>
+            </graphicData>
+            <offset>(0,1.0,0)</offset>
+          </li>
+        </overlays>
+      </li>
     </comps>
     <designationCategory>Furniture</designationCategory>
     <designationHotKey>Misc10</designationHotKey>
-    <researchPrerequisites><li>LotRD_FurnitureTwo</li></researchPrerequisites>
+    <researchPrerequisites>
+      <li>LotRD_FurnitureTwo</li>
+    </researchPrerequisites>
   </ThingDef>
-  
+
   <ThingDef ParentName="FurnitureWithQualityBase">
     <defName>LotRD_DwarvenWallLight</defName>
-    <label>dwarven ithildin wall light</label>
-	<thingClass>Building</thingClass>
+    <label>Dwarven ithildin wall light</label>
+    <thingClass>Building</thingClass>
     <description>Imbued with the mithril alloy of ithildin, this wall light gives off a beautiful blue luminescence.</description>
-    <category>Building</category><thingCategories><li>Buildings</li></thingCategories>
-	<building>
-	  <isEdifice>false</isEdifice>
-	</building>
+    <category>Building</category>
+    <thingCategories>
+      <li>Buildings</li>
+    </thingCategories>
+    <building>
+      <isEdifice>false</isEdifice>
+    </building>
     <clearBuildingArea>false</clearBuildingArea>
     <graphicData>
       <texPath>Things/Building/Furniture/edmundWulfgarthDwarvenWallLight</texPath>
       <graphicClass>Graphic_Single</graphicClass>
       <drawRotated>true</drawRotated>
-	  <shaderType>CutoutComplex</shaderType>
+      <shaderType>CutoutComplex</shaderType>
       <damageData>
         <rect>(0.35,0.35,0.3,0.3)</rect>
       </damageData>
@@ -318,22 +336,22 @@
     <costStuffCount>15</costStuffCount>
     <costList>
       <Steel>3</Steel>
-      <ComponentIndustrial>2</ComponentIndustrial>	  
-	</costList>	
+      <ComponentIndustrial>2</ComponentIndustrial>
+    </costList>
     <rotatable>true</rotatable>
     <altitudeLayer>MoteOverhead</altitudeLayer>
     <passability>PassThroughOnly</passability>
-	<pathCost>8</pathCost>
+    <pathCost>8</pathCost>
     <tickerType>Normal</tickerType>
     <drawerType>RealtimeOnly</drawerType>
-	<minifiedDef>MinifiedThing</minifiedDef>	
+    <minifiedDef>MinifiedThing</minifiedDef>
     <fillPercent>0.15</fillPercent>
     <statBases>
-      <Mass>5</Mass>		
+      <Mass>5</Mass>
       <MaxHitPoints>40</MaxHitPoints>
       <WorkToBuild>160</WorkToBuild>
       <Flammability>1.0</Flammability>
-	  <Beauty>1</Beauty>
+      <Beauty>1</Beauty>
     </statBases>
     <selectable>true</selectable>
     <soundImpactDefault>BulletImpact_Ground</soundImpactDefault>
@@ -342,33 +360,38 @@
         <glowRadius>10</glowRadius>
         <glowColor>(0,255,255,0)</glowColor>
       </li>
-      <li Class="CompProperties_Flickable"/>	  
+      <li Class="CompProperties_Flickable"/>
     </comps>
     <placeWorkers>
       <li>JecsTools.PlaceWorker_OnTopOfWalls</li>
     </placeWorkers>
     <designationCategory>Furniture</designationCategory>
-    <researchPrerequisites><li>LotRD_FurnitureThree</li></researchPrerequisites>
+    <researchPrerequisites>
+      <li>LotRD_FurnitureThree</li>
+    </researchPrerequisites>
   </ThingDef>
 
 
   <ThingDef ParentName="ArtableFurnitureBase">
     <defName>LotRD_DwarvenStreetLamp</defName>
-    <label>dwarven ithildin lamp</label>
+    <label>Dwarven ithildin lamp</label>
     <description>A standing lamp that uses the mithril alloy ithildin to create endless blue light.</description>
-	<thingClass>Dwarves.Building_StreetLamp</thingClass>
-    <category>Building</category><thingCategories><li>Buildings</li></thingCategories>	
+    <thingClass>Dwarves.Building_StreetLamp</thingClass>
+    <category>Building</category>
+    <thingCategories>
+      <li>Buildings</li>
+    </thingCategories>
     <graphicData>
       <texPath>Things/Building/Furniture/edmundWulfgarthDwarvenLampPost</texPath>
       <graphicClass>Graphic_Single</graphicClass>
       <drawRotated>false</drawRotated>
       <drawSize>(6.0,6.0)</drawSize>
-	  <shaderType>CutoutComplex</shaderType>
+      <shaderType>CutoutComplex</shaderType>
       <damageData>
         <rect>(0.35,0.35,0.3,0.3)</rect>
       </damageData>
     </graphicData>
-	<uiIconPath>Things/Building/Furniture/edmundWulfgarthDwarvenLampPost_ico</uiIconPath>	
+    <uiIconPath>Things/Building/Furniture/edmundWulfgarthDwarvenLampPost_ico</uiIconPath>
     <stuffCategories>
       <li>Metallic</li>
       <li>Stony</li>
@@ -376,36 +399,38 @@
     <costStuffCount>40</costStuffCount>
     <costList>
       <Steel>7</Steel>
-      <ComponentIndustrial>2</ComponentIndustrial>	  
-	</costList>		
+      <ComponentIndustrial>2</ComponentIndustrial>
+    </costList>
     <rotatable>false</rotatable>
     <altitudeLayer>MoteOverhead</altitudeLayer>
     <passability>Impassable</passability>
-	<pathCost>8</pathCost>
+    <pathCost>8</pathCost>
     <tickerType>Normal</tickerType>
     <drawerType>RealtimeOnly</drawerType>
     <fillPercent>0.15</fillPercent>
     <statBases>
-      <Mass>150</Mass>	
+      <Mass>150</Mass>
       <MaxHitPoints>40</MaxHitPoints>
       <WorkToBuild>160</WorkToBuild>
       <Flammability>1.0</Flammability>
-	  <Beauty>3</Beauty>
+      <Beauty>3</Beauty>
     </statBases>
-	<size>(1,1)</size>
+    <size>(1,1)</size>
     <selectable>true</selectable>
     <soundImpactDefault>BulletImpact_Ground</soundImpactDefault>
     <comps>
       <li Class="CompProperties_Flickable"/>
-      <li Class="CompProperties_Breakdownable"/>	  
+      <li Class="CompProperties_Breakdownable"/>
     </comps>
     <placeWorkers>
       <li>PlaceWorker_NotUnderRoof</li>
-    </placeWorkers>	
+    </placeWorkers>
     <designationCategory>Furniture</designationCategory>
-    <researchPrerequisites><li>LotRD_FurnitureThree</li></researchPrerequisites>
-  </ThingDef>    
-	
+    <researchPrerequisites>
+      <li>LotRD_FurnitureThree</li>
+    </researchPrerequisites>
+  </ThingDef>
+
   <ThingDef ParentName="BuildingBase">
     <defName>LotRD_GasLampGlower</defName>
     <label>dwarven street lamp glower</label>
@@ -415,7 +440,7 @@
       <graphicClass>Graphic_Single</graphicClass>
       <drawRotated>false</drawRotated>
       <drawSize>(6.0,6.0)</drawSize>
-	  <shaderType>CutoutComplex</shaderType>
+      <shaderType>CutoutComplex</shaderType>
       <damageData>
         <rect>(0.35,0.35,0.3,0.3)</rect>
       </damageData>
@@ -425,18 +450,18 @@
     <altitudeLayer>MoteOverhead</altitudeLayer>
     <tickerType>Normal</tickerType>
     <drawerType>RealtimeOnly</drawerType>
- 	<size>(1,1)</size>
+    <size>(1,1)</size>
     <selectable>false</selectable>
     <comps>
       <li Class="CompProperties_Glower">
         <glowRadius>12</glowRadius>
         <glowColor>(0,255,255,0)</glowColor>
       </li>
-      <li Class="CompProperties_Flickable"/>  
+      <li Class="CompProperties_Flickable"/>
     </comps>
   </ThingDef>
 
 
 
-  
+
 </Defs>

--- a/Defs/ThingDefs_Buildings/LotRD_Production.xml
+++ b/Defs/ThingDefs_Buildings/LotRD_Production.xml
@@ -2,7 +2,7 @@
 <Defs>
 
 
-	<WorkGiverDef>
+  <WorkGiverDef>
     <defName>LotRD_TakeMeadOutOfFermentingBarrel</defName>
     <label>take dwarven mead out of fermenting barrels</label>
     <giverClass>Dwarves.WorkGiver_TakeMeadOutOfFermentingBarrel</giverClass>
@@ -14,7 +14,7 @@
       <li>Manipulation</li>
     </requiredCapacities>
   </WorkGiverDef>
-  
+
   <WorkGiverDef>
     <defName>LotRD_FillFermentingBarrel</defName>
     <label>fill fermenting barrels</label>
@@ -35,19 +35,19 @@
     <reportString>filling TargetA.</reportString>
     <suspendable>false</suspendable>
   </JobDef>
-  
+
   <JobDef>
     <defName>LotRD_TakeMeadOutOfFermentingBarrel</defName>
     <driverClass>Dwarves.JobDriver_TakeMeadOutOfFermentingBarrel</driverClass>
     <reportString>taking dwarven mead out of TargetA.</reportString>
   </JobDef>
-  
+
 
   <ThingDef ParentName="BuildingBase">
     <defName>LotRD_FermentingBarrel</defName>
     <label>fermenting barrel (mead)</label>
-	<category>Building</category>
-	
+    <category>Building</category>
+
     <thingClass>Dwarves.Building_FermentingMeadBarrel</thingClass>
     <graphicData>
       <texPath>Things/Building/Production/FermentingBarrel</texPath>
@@ -75,18 +75,20 @@
       <Steel>10</Steel>
       <WoodLog>30</WoodLog>
     </costList>
-		<comps>
-			<li Class="CompProperties_TemperatureRuinable">
-				<minSafeTemperature>-1</minSafeTemperature>
-				<maxSafeTemperature>32</maxSafeTemperature>
-				<progressPerDegreePerTick>0.00001</progressPerDegreePerTick>
-			</li>
-		</comps>
+    <comps>
+      <li Class="CompProperties_TemperatureRuinable">
+        <minSafeTemperature>-1</minSafeTemperature>
+        <maxSafeTemperature>32</maxSafeTemperature>
+        <progressPerDegreePerTick>0.00001</progressPerDegreePerTick>
+      </li>
+    </comps>
     <tickerType>Rare</tickerType>
     <rotatable>true</rotatable>
     <designationCategory>Production</designationCategory>
     <constructEffect>ConstructWood</constructEffect>
-    <researchPrerequisites><li>LotRD_Brewing</li></researchPrerequisites>
+    <researchPrerequisites>
+      <li>LotRD_Brewing</li>
+    </researchPrerequisites>
   </ThingDef>
 
 </Defs>

--- a/Defs/ThingDefs_Items/LotRD_Toys.xml
+++ b/Defs/ThingDefs_Items/LotRD_Toys.xml
@@ -4,7 +4,7 @@
 
   <ThingDef ParentName="ResourceBase">
     <defName>LotRD_DwarfPuzzleBox</defName>
-    <label>puzzle box (dwarfmake)</label>
+    <label>Puzzle box (Dwarfmake)</label>
     <description>A magic puzzle box of dwarf-make with holes, slides, and knobs.</description>
     <graphicData>
       <texPath>Things/Item/Toys/sheidulaPuzzleBox</texPath>
@@ -18,7 +18,7 @@
     <stackLimit>1</stackLimit>
     <useHitPoints>true</useHitPoints>
     <recipeMaker>
-			<researchPrerequisite>LotRD_ToyMaking</researchPrerequisite>
+      <researchPrerequisite>LotRD_ToyMaking</researchPrerequisite>
       <workSpeedStat>SmithingSpeed</workSpeedStat>
       <workSkill>Crafting</workSkill>
       <effectWorking>Smith</effectWorking>
@@ -29,14 +29,14 @@
       </recipeUsers>
     </recipeMaker>
     <costList>
-	  <WoodLog>100</WoodLog>
+      <WoodLog>100</WoodLog>
     </costList>
     <statBases>
       <MarketValue>130</MarketValue>
       <MaxHitPoints>100</MaxHitPoints>
       <Mass>2</Mass>
       <JoyGainFactor>1</JoyGainFactor>
-	  <Beauty>1</Beauty>
+      <Beauty>1</Beauty>
     </statBases>
     <thingCategories>
       <li>Items</li>
@@ -53,15 +53,15 @@
       <li>Medieval</li>
     </tradeTags>
   </ThingDef>
-  
+
   <ThingDef ParentName="ResourceBase">
     <defName>LotRD_DwarfMarbleLabyrinth</defName>
-    <label>marble labyrinth (dwarfmake)</label>
+    <label>Marble labyrinth (Dwarfmake)</label>
     <description>An enchanted marble labyrinth -- seemingly once reaching the end of one level, the box slides away to reveal additional layers in the maze.</description>
     <graphicData>
       <texPath>Things/Item/Toys/sheidulaMarbleMaze</texPath>
       <graphicClass>Graphic_Single</graphicClass>
-	  <drawSize>0.5</drawSize>
+      <drawSize>0.5</drawSize>
       <onGroundRandomRotateAngle>35</onGroundRandomRotateAngle>
       <color>(133,97,67)</color>
     </graphicData>
@@ -75,13 +75,13 @@
       <MaxHitPoints>100</MaxHitPoints>
       <Mass>2</Mass>
       <JoyGainFactor>1</JoyGainFactor>
-	  <Beauty>1</Beauty>
+      <Beauty>1</Beauty>
     </statBases>
     <thingCategories>
       <li>Items</li>
     </thingCategories>
     <recipeMaker>
-			<researchPrerequisite>LotRD_ToyMaking</researchPrerequisite>
+      <researchPrerequisite>LotRD_ToyMaking</researchPrerequisite>
       <workSpeedStat>SmithingSpeed</workSpeedStat>
       <workSkill>Crafting</workSkill>
       <effectWorking>Smith</effectWorking>
@@ -92,12 +92,12 @@
       </recipeUsers>
     </recipeMaker>
     <costList>
-	  <WoodLog>80</WoodLog>
+      <WoodLog>80</WoodLog>
     </costList>
     <comps>
-    <li>
+      <li>
         <compClass>CompQuality</compClass>
-    </li>
+      </li>
     </comps>
     <drawGUIOverlay>false</drawGUIOverlay>
     <tradeability>All</tradeability>
@@ -106,10 +106,10 @@
       <li>Medieval</li>
     </tradeTags>
   </ThingDef>
-  
+
   <ThingDef ParentName="ResourceBase">
     <defName>LotRD_DwarfElfToy</defName>
-    <label>elf doll (dwarfmake)</label>
+    <label>Elf doll (Dwarfmake)</label>
     <description>A delightul child's toy enchanted by dwarf magic. It can talk when pressed gently. The maker of this doll also enchanted it with a few "oofs" when squeezed harder than normal.</description>
     <graphicData>
       <texPath>Things/Item/Toys/sheidulaElfDoll</texPath>
@@ -126,9 +126,10 @@
       <MaxHitPoints>100</MaxHitPoints>
       <Mass>2</Mass>
       <JoyGainFactor>1</JoyGainFactor>
-	  <Beauty>1</Beauty>
+      <Beauty>1</Beauty>
     </statBases>
     <recipeMaker>
+      <researchPrerequisite>LotRD_ToyMaking</researchPrerequisite>
       <workSpeedStat>TailoringSpeed</workSpeedStat>
       <workSkill>Crafting</workSkill>
       <effectWorking>Tailor</effectWorking>
@@ -139,15 +140,15 @@
       </recipeUsers>
     </recipeMaker>
     <costList>
-	  <Cloth>30</Cloth>
+      <Cloth>30</Cloth>
     </costList>
     <thingCategories>
       <li>Items</li>
     </thingCategories>
     <comps>
-    <li>
+      <li>
         <compClass>CompQuality</compClass>
-    </li>
+      </li>
     </comps>
     <drawGUIOverlay>false</drawGUIOverlay>
     <tradeability>All</tradeability>


### PR DESCRIPTION
- Fixes `LotRD_FurnitureThree`'s description to actually match what it allows you to build.
- Makes `LotRD_FurnitureOne` a requirement for `LotRD_FurnitureTwo`.
- Formats the Research and FurnitureLightning files.